### PR TITLE
Fix test fail (raised on CRAN)

### DIFF
--- a/tests/testthat/test-d.spls.GLA.R
+++ b/tests/testthat/test-d.spls.GLA.R
@@ -30,10 +30,10 @@ test_that("d.spls.GLA works", {
   expect_equal(dim(mod.dspls$fitted.values), c(n,ncp))
 
   # residuals
-  expect_setequal(mod.dspls$residuals, y-mod.dspls$fitted.values)
+  expect_equal(mod.dspls$residuals, y-mod.dspls$fitted.values, tolerance = 1e-5)
 
   # mean of X
-  expect_setequal(apply(X, 2, mean), mod.dspls$Xmean)
+  expect_equal(apply(X, 2, mean), mod.dspls$Xmean, tolerance = 1e-5)
 
   # zerovar
   for (i in 2:ncp)

--- a/tests/testthat/test-d.spls.GLB.R
+++ b/tests/testthat/test-d.spls.GLB.R
@@ -30,10 +30,10 @@ expect_equal(dim(mod.dspls$loadings), c(p,ncp))
 expect_equal(dim(mod.dspls$fitted.values), c(n,ncp))
 
 # residuals
-expect_setequal(mod.dspls$residuals, y-mod.dspls$fitted.values)
+expect_equal(mod.dspls$residuals, y-mod.dspls$fitted.values, tolerance = 1e-5)
 
 # mean of X
-expect_setequal(apply(X, 2, mean), mod.dspls$Xmean)
+expect_equal(apply(X, 2, mean), mod.dspls$Xmean, tolerance = 1e-5)
 
 # zerovar
 for (i in 2:ncp)

--- a/tests/testthat/test-d.spls.GLC.R
+++ b/tests/testthat/test-d.spls.GLC.R
@@ -30,10 +30,10 @@ test_that("d.spls.GLC works", {
   expect_equal(dim(mod.dspls$fitted.values), c(n,ncp))
 
   #residuals
-  expect_setequal(mod.dspls$residuals, y-mod.dspls$fitted.values)
+  expect_equal(mod.dspls$residuals, y-mod.dspls$fitted.values, tolerance = 1e-5)
 
   #Mean of X
-  expect_setequal(apply(X, 2, mean), mod.dspls$Xmean)
+  expect_equal(apply(X, 2, mean), mod.dspls$Xmean, tolerance = 1e-5)
 
   #zerovar
   for (i in 2:ncp)

--- a/tests/testthat/test-d.spls.LS.R
+++ b/tests/testthat/test-d.spls.LS.R
@@ -24,7 +24,7 @@ test_that("d.spls.LS works", {
   expect_equal(dim(mod.dspls$fitted.values), c(n,ncp))
 
   # residuals
-  expect_setequal(mod.dspls$residuals, y-mod.dspls$fitted.values)
+  expect_equal(mod.dspls$residuals, y-mod.dspls$fitted.values, tolerance = 1e-5)
 
   # mean of X
   expect_equal(apply(X, 2, mean), mod.dspls$Xmean)

--- a/tests/testthat/test-d.spls.lasso.R
+++ b/tests/testthat/test-d.spls.lasso.R
@@ -23,10 +23,10 @@ test_that("d.spls.lasso works", {
   expect_equal(dim(mod.dspls$fitted.values), c(n,ncp))
 
   #residuals
-  expect_setequal(mod.dspls$residuals, y-mod.dspls$fitted.values)
+  expect_equal(mod.dspls$residuals, y-mod.dspls$fitted.values, tolerance = 1e-5)
 
   #Mean of X
-  expect_setequal(apply(X, 2, mean), mod.dspls$Xmean)
+  expect_equal(apply(X, 2, mean), mod.dspls$Xmean, tolerance = 1e-5)
 
   #zerovar
   for (i in 2:ncp)

--- a/tests/testthat/test-d.spls.metric.R
+++ b/tests/testthat/test-d.spls.metric.R
@@ -25,13 +25,22 @@ test_that("d.spls.metric works", {
 
   i=sample(1:ncp,1)
   #RMSE
-  expect_setequal(predmetric$RMSE[i], sqrt(mean((y-mod.dspls$fitted.values[,i])^2)))
+  expect_equal(
+    predmetric$RMSE[i],
+    sqrt(mean((y-mod.dspls$fitted.values[,i])^2)),
+    tolerance = 1e-5)
 
   #MAE
-  expect_setequal(predmetric$MAE[i], mean(abs(y-mod.dspls$fitted.values[,i])))
+  expect_equal(
+    predmetric$MAE[i],
+    mean(abs(y-mod.dspls$fitted.values[,i])),
+    tolerance = 1e-5)
 
   #R2
-  expect_setequal(predmetric$Rsquared[i], 1-sum((mod.dspls$residuals[,i])^2)/sum((y-mean(y))^2))
+  expect_equal(
+    predmetric$Rsquared[i],
+    1-sum((mod.dspls$residuals[,i])^2)/sum((y-mean(y))^2),
+    tolerance = 1e-5)
   expect_lt(predmetric$Rsquared[i],1)
 
 })

--- a/tests/testthat/test-d.spls.pls.R
+++ b/tests/testthat/test-d.spls.pls.R
@@ -22,12 +22,10 @@ test_that("d.spls.pls works", {
   expect_equal(dim(mod.dspls$fitted.values), c(n,ncp))
 
   # residuals
-  expect_setequal(mod.dspls$residuals, y-mod.dspls$fitted.values)
+  expect_equal(mod.dspls$residuals, y-mod.dspls$fitted.values, tolerance = 1e-5)
 
   # mean of X
-  expect_setequal(apply(X, 2, mean), mod.dspls$Xmean)
-
-
+  expect_equal(apply(X, 2, mean), mod.dspls$Xmean, tolerance = 1e-5)
 
 })
 

--- a/tests/testthat/test-d.spls.predict.R
+++ b/tests/testthat/test-d.spls.predict.R
@@ -38,6 +38,10 @@ yvalhat=d.spls.predict(mod.dspls,Xval, liste_cp=liste_cp)
 expect_equal(dim(yvalhat), c(length(indval),length(liste_cp)))
 
 #Prediction testing
-expect_setequal(ycalhat, d.spls.predict(mod.dspls,Xcal, liste_cp=1:ncp))
-  })
+expect_equal(
+  ycalhat, d.spls.predict(mod.dspls,Xcal, liste_cp=1:ncp),
+  tolerance = 1e-5
+)
+
+})
 

--- a/tests/testthat/test-d.spls.ridge.R
+++ b/tests/testthat/test-d.spls.ridge.R
@@ -24,10 +24,10 @@ expect_equal(dim(mod.dspls$loadings), c(p,ncp))
 expect_equal(dim(mod.dspls$fitted.values), c(n,ncp))
 
 # residuals
-expect_setequal(mod.dspls$residuals, y-mod.dspls$fitted.values)
+expect_equal(mod.dspls$residuals, y-mod.dspls$fitted.values, tolerance = 1e-5)
 
 # mean of X
-expect_setequal(apply(X, 2, mean), mod.dspls$Xmean)
+expect_equal(apply(X, 2, mean), mod.dspls$Xmean, tolerance = 1e-5)
 
 # zerovar
 for (i in 2:ncp)


### PR DESCRIPTION
When submitting on CRAN, issue in `test-d.spls.predict.R` with:
```R
expect_setequal(X, Y)
```

Replace by:
```R
expect_equal(X, Y, tolerance = 1e-5)
```

Should fix the problem (tests are still passing).